### PR TITLE
Pin rest.filter as the scoped-resource-set impl; de-DS conflicting te…

### DIFF
--- a/org.eclipse.fennec.model.atlas.rest.application/bnd.bnd
+++ b/org.eclipse.fennec.model.atlas.rest.application/bnd.bnd
@@ -30,3 +30,15 @@
 	org.eclipse.fennec.model.atlas.management.lucene;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.common;version=snapshot,\
 	org.eclipse.fennec.codec.rest;version=latest,\
+
+# Hard runtime requirement on the Model Atlas scoped-resource-set
+# filter (provided by org.eclipse.fennec.model.atlas.rest.filter).
+# Without this, the @Context ResourceSet injection would not see the
+# scope/stage-aware ScopedResourceSetProvider and requests under
+# /{scopeName}/stages/{stageName}/... would resolve against the
+# default ResourceSet. The unique osgi.implementation identifier also
+# ensures the resolver picks the production filter bundle, not the
+# test bundle (which deliberately does not declare this capability).
+Require-Capability: \
+	osgi.implementation;\
+		filter:="(&(osgi.implementation=org.eclipse.fennec.model.atlas.scoped-resource-set)(version>=1.0.0))"

--- a/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/ScopedResourceSetIntegrationTest.java
+++ b/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/ScopedResourceSetIntegrationTest.java
@@ -18,7 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Dictionary;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -32,16 +34,23 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.fennec.emf.osgi.annotation.require.RequireEMF;
+import org.eclipse.fennec.model.atlas.mediatypes.api.SupportedMediatype;
+import org.eclipse.fennec.model.atlas.workflow.ResourceSetCollector;
+import org.eclipse.fennec.model.atlas.workflow.ScopeServiceCollector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.annotations.RequireConfigurationAdmin;
 import org.osgi.service.jakartars.runtime.JakartarsServiceRuntime;
 import org.osgi.service.jakartars.runtime.dto.ApplicationDTO;
 import org.osgi.service.jakartars.runtime.dto.ResourceDTO;
 import org.osgi.service.jakartars.runtime.dto.RuntimeDTO;
 import org.osgi.service.jakartars.whiteboard.annotations.RequireJakartarsWhiteboard;
+import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.junit5.context.BundleContextExtension;
 import org.osgi.test.junit5.service.ServiceExtension;
@@ -83,12 +92,6 @@ public class ScopedResourceSetIntegrationTest {
 	private static final String SINGLETON_RESOURCE_NAME = "SingletonResourceSetClassResource";
 
 	@InjectService(timeout = 5_000)
-	TestResourceSetCollector testCollector;
-
-	@InjectService(timeout = 5_000)
-	TestScopeServiceCollector testScopeCollector;
-
-	@InjectService(timeout = 5_000)
 	ClientBuilder clientBuilder;
 
 	@InjectService(timeout = 5_000)
@@ -98,12 +101,38 @@ public class ScopedResourceSetIntegrationTest {
 	private CountingCso scopeAStageA;
 	private CountingCso scopeBStageB;
 
+	// Test overrides are instantiated directly and registered manually with
+	// MAX_VALUE service.ranking so the production DYNAMIC/GREEDY references
+	// rebind to them. Manual registration keeps these classes out of bnd's
+	// auto-generated osgi.service Provide-Capability set for this bundle,
+	// so the workspace-aware resolver no longer treats this test bundle as
+	// a candidate provider for ResourceSetCollector / ScopeServiceCollector
+	// / SupportedMediatype in production resolves.
+	private TestResourceSetCollector testCollector;
+	private TestScopeServiceCollector testScopeCollector;
+	private final List<ServiceRegistration<?>> registrations = new ArrayList<>();
+
 	@BeforeEach
-	public void setUp() throws InterruptedException {
+	public void setUp(@InjectBundleContext BundleContext context) throws InterruptedException {
 		client = clientBuilder.build();
 
-		testCollector.clear();
-		testScopeCollector.clear();
+		testCollector = new TestResourceSetCollector();
+		testScopeCollector = new TestScopeServiceCollector();
+		TestSupportedMediatype testMediatype = new TestSupportedMediatype();
+
+		registrations.add(context.registerService(
+				new String[] { ResourceSetCollector.class.getName(),
+						TestResourceSetCollector.class.getName() },
+				testCollector, maxRanking()));
+		registrations.add(context.registerService(
+				new String[] { ScopeServiceCollector.class.getName(),
+						TestScopeServiceCollector.class.getName() },
+				testScopeCollector, maxRanking()));
+		registrations.add(context.registerService(
+				new String[] { SupportedMediatype.class.getName(),
+						TestSupportedMediatype.class.getName() },
+				testMediatype, maxRanking()));
+
 		testScopeCollector.register("scopeA");
 		testScopeCollector.register("scopeB");
 
@@ -129,8 +158,26 @@ public class ScopedResourceSetIntegrationTest {
 			client.close();
 			client = null;
 		}
-		testCollector.clear();
-		testScopeCollector.clear();
+		for (ServiceRegistration<?> registration : registrations) {
+			try {
+				registration.unregister();
+			} catch (IllegalStateException alreadyUnregistered) {
+				// fine — the framework already cleaned this up
+			}
+		}
+		registrations.clear();
+		if (testCollector != null) {
+			testCollector.clear();
+		}
+		if (testScopeCollector != null) {
+			testScopeCollector.clear();
+		}
+	}
+
+	private static Dictionary<String, Object> maxRanking() {
+		Dictionary<String, Object> props = new Hashtable<>();
+		props.put(Constants.SERVICE_RANKING, Integer.MAX_VALUE);
+		return props;
 	}
 
 	@Test

--- a/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestResourceSetCollector.java
+++ b/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestResourceSetCollector.java
@@ -19,24 +19,28 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fennec.model.atlas.workflow.ResourceSetCollector;
 import org.osgi.service.component.ComponentServiceObjects;
-import org.osgi.service.component.annotations.Component;
 
 /**
- * High-priority test override of {@link ResourceSetCollector}. Tests register
- * scope/stage-specific {@link CountingCso} entries via
- * {@link #register(String, String, CountingCso)}. The
- * {@code ScopedResourceSetFeature}'s DYNAMIC/GREEDY reference will pick this
- * instance because of the {@code service.ranking = Integer.MAX_VALUE}.
+ * High-priority test override of {@link ResourceSetCollector}. The test
+ * harness instantiates it directly and registers it as an OSGi service via
+ * {@code BundleContext.registerService} with {@code service.ranking = MAX_VALUE}
+ * so the production {@code ScopedResourceSetProvider}'s DYNAMIC/GREEDY
+ * reference picks it.
  *
- * <p>This subclass intentionally does not re-declare the parent's
- * {@code @Reference} bindings: DS only processes annotations on the declared
- * component class, so the inherited tracking maps stay empty and only entries
- * registered through {@link #register(String, String, CountingCso)} are
- * visible.
+ * <p>This class deliberately carries no {@code @Component} annotation. If it
+ * did, bnd would emit an {@code osgi.service} Provide-Capability entry for
+ * the {@link ResourceSetCollector} object class in this bundle's manifest,
+ * which would make the workspace-aware resolver consider the test bundle as
+ * a candidate provider for any production bundle that requires the
+ * production {@code ResourceSetCollector} — exactly the pull-in problem the
+ * runblacklist on this bundle used to work around. With manual registration,
+ * the manifest stays clean.
+ *
+ * <p>Because the parent class's {@code @Reference} bind methods are
+ * processed by DS only on the declared component (which this class is not),
+ * the inherited tracking maps stay empty and only entries registered through
+ * {@link #register(String, String, ComponentServiceObjects)} are visible.
  */
-@Component(
-		service = { ResourceSetCollector.class, TestResourceSetCollector.class },
-		property = "service.ranking:Integer=2147483647")
 public class TestResourceSetCollector extends ResourceSetCollector {
 
 	private final Map<String, ComponentServiceObjects<ResourceSet>> entries = new ConcurrentHashMap<>();

--- a/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestScopeServiceCollector.java
+++ b/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestScopeServiceCollector.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.fennec.model.atlas.wf.workflowapi.ScopeService;
 import org.eclipse.fennec.model.atlas.workflow.ScopeServiceCollector;
-import org.osgi.service.component.annotations.Component;
 
 /**
  * High-priority test override of {@link ScopeServiceCollector}. Hands back a
@@ -29,10 +28,10 @@ import org.osgi.service.component.annotations.Component;
  * {@link #register(String)} so that the side-by-side
  * {@code ModelAtlasRequestFilter} (which validates scope names ahead of the
  * binder) lets requests through to the test resource.
+ *
+ * <p>No {@code @Component} annotation — registered manually by the test
+ * harness, see the rationale on {@link TestResourceSetCollector}.
  */
-@Component(
-		service = { ScopeServiceCollector.class, TestScopeServiceCollector.class },
-		property = "service.ranking:Integer=2147483647")
 public class TestScopeServiceCollector extends ScopeServiceCollector {
 
 	@SuppressWarnings("rawtypes")

--- a/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestSupportedMediatype.java
+++ b/org.eclipse.fennec.model.atlas.rest.filter.tests/src/org/eclipse/fennec/model/atlas/rest/filter/tests/TestSupportedMediatype.java
@@ -16,17 +16,16 @@ package org.eclipse.fennec.model.atlas.rest.filter.tests;
 import java.util.List;
 
 import org.eclipse.fennec.model.atlas.mediatypes.api.SupportedMediatype;
-import org.osgi.service.component.annotations.Component;
 
 /**
  * High-priority test override of {@link SupportedMediatype}. Reports
  * {@code text/plain} and {@code application/json} as supported so the
  * {@code ModelAtlasRequestFilter}'s media-type resolution passes for the test
  * resource.
+ *
+ * <p>No {@code @Component} annotation — registered manually by the test
+ * harness, see the rationale on {@link TestResourceSetCollector}.
  */
-@Component(
-		service = { SupportedMediatype.class, TestSupportedMediatype.class },
-		property = "service.ranking:Integer=2147483647")
 public class TestSupportedMediatype implements SupportedMediatype {
 
 	@Override

--- a/org.eclipse.fennec.model.atlas.rest.filter/bnd.bnd
+++ b/org.eclipse.fennec.model.atlas.rest.filter/bnd.bnd
@@ -10,3 +10,15 @@
 	org.osgi.service.cdi,\
 	org.osgi.service.component,\
 	org.glassfish.hk2.api
+
+# Declares this bundle as the implementation of the Model Atlas
+# scoped-resource-set filter feature (ScopedResourceSetProvider +
+# ModelAtlasRequestFilter + HK2MultiExceptionMapper). Consumers
+# (e.g. rest.application) pin the production filter via the
+# matching Require-Capability so the resolver cannot substitute a
+# test bundle that does not declare this capability.
+Provide-Capability: \
+	osgi.implementation;\
+		osgi.implementation="org.eclipse.fennec.model.atlas.scoped-resource-set";\
+		version:Version="1.0.0";\
+		uses:="org.eclipse.fennec.codec.rest.jakartas.spi"

--- a/org.eclipse.fennec.model.atlas.rest.tests/test.bndrun
+++ b/org.eclipse.fennec.model.atlas.rest.tests/test.bndrun
@@ -41,8 +41,14 @@
 
 -runblacklist: \
 	bnd.identity;id='org.eclipse.uml2.uml';version='[0.0.0,5.6.0)',\
-	bnd.identity;id='org.eclipse.fennec.model.atlas.management.apicurio',\
-	bnd.identity;id='org.eclipse.fennec.model.atlas.rest.filter.tests'
+	bnd.identity;id='org.eclipse.fennec.model.atlas.management.apicurio'
+# rest.filter.tests is no longer blacklisted: the test stubs that used to
+# overlap with production services (ResourceSetCollector,
+# ScopeServiceCollector, SupportedMediatype) are now registered manually
+# from the test class, so bnd no longer emits matching osgi.service
+# Provide-Capability entries in the test bundle's manifest. The
+# workspace-aware resolver therefore stops treating it as a candidate
+# provider for those production requirements.
 
 
 -runbundles: \
@@ -115,7 +121,6 @@
 	org.eclipse.fennec.model.atlas.rest.common;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.ecore.xmi;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.filter;version=snapshot,\
-	org.eclipse.fennec.model.atlas.rest.filter.tests;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.jsonschema;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.model;version=snapshot,\
 	org.eclipse.fennec.model.atlas.rest.tests;version=snapshot,\


### PR DESCRIPTION
…st stubs

Adds an osgi.implementation=org.eclipse.fennec.model.atlas.scoped-resource-set capability on rest.filter with a matching hard requirement on rest.application, so the resolver always picks the production filter bundle.

Drops @Component from TestResourceSetCollector / TestScopeServiceCollector / TestSupportedMediatype and registers them manually from the test setUp via BundleContext.registerService with service.ranking=MAX_VALUE. With no DS metadata, bnd no longer emits matching osgi.service Provide-Capability entries in the test bundle's manifest, so the workspace-aware resolver stops treating rest.filter.tests as a candidate provider for ResourceSetCollector / ScopeServiceCollector / SupportedMediatype. The rest.filter.tests blacklist in rest.tests/test.bndrun is dropped.